### PR TITLE
Fixed a minor bug in constructor to DefinedAlphabet

### DIFF
--- a/src/main/java/alphabet/DefinedAlphabet.java
+++ b/src/main/java/alphabet/DefinedAlphabet.java
@@ -1,5 +1,6 @@
 package alphabet;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,7 +15,7 @@ public class DefinedAlphabet implements Alphabet {
 	}
 
 	public DefinedAlphabet(List<Integer> codePoints) {
-		this.codePoints = codePoints;
+		this.codePoints = new ArrayList<>(codePoints);
 	}
 
 	@Override


### PR DESCRIPTION
Now creates a copy of the incoming list instead of directly referencing it.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>