### PR TITLE
Updated the build file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,17 @@ jacocoTestReport {
             enabled true
         }
     }
+
+    afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: ['core/Main.java',
+                              'util/PredefinedAlphabetStrings.java'])
+        })
+    }
 }
+
+
 
 tasks.withType(Test) {
     testLogging {


### PR DESCRIPTION
Jacoco will now not count classes not meant to be tested towards the total test coverage.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>