### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ jacocoTestReport {
     afterEvaluate {
         classDirectories = files(classDirectories.files.collect {
             fileTree(dir: it,
-                    exclude: ['core.Main.java',
-                              'util.PredefinedAlphabetStrings.java'])
+                    exclude: ['**/*Main*.*',
+                              '**/*PredefinedAlphabetStrings*.*'])
         })
     }
 }


### PR DESCRIPTION
Jacoco should now exclude the classes not meant to be tested. This time it should work.

Signed-off-by: Emil Englesson <englesson.emil@gmail.com>